### PR TITLE
Add :maintainLockFilesWeekly to renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,7 @@
         ":prHourlyLimitNone",
         ":prConcurrentLimitNone",
         ":disableDependencyDashboard",
-        ":separateMultipleMajorReleases"
+        ":separateMultipleMajorReleases",
+        ":maintainLockFilesWeekly"
     ]
 }


### PR DESCRIPTION
Renovate does not update  indirect dependencies of the lock file by default. This should update the entire lock file every Monday morning.
